### PR TITLE
Fix display of challenge dependency names containing spaces

### DIFF
--- a/CTFd/plugins/challenge-dependencies/assets/dependencies.html
+++ b/CTFd/plugins/challenge-dependencies/assets/dependencies.html
@@ -38,7 +38,7 @@
                             <input value="{{ nonce }}" name="nonce" hidden>
                             <input value="{{ dep.id }}" name="dependency_id" hidden>
                             <input type="text" style="border-width: 0; background-color: transparent;" 
-                                value= {{ dep.name }} disabled>
+                                value="{{ dep.name }}" disabled>
                             <span class="delete-dependency" data-toggle="tooltip"
                                 data-placement="top" chal-id="{{ challenge.id }}" 
                                 title="Delete dependency">


### PR DESCRIPTION
Fix challenge dependency names only showing first word of challenge name when challenge name contains spaces.